### PR TITLE
Create redirect configuration for Netlify.

### DIFF
--- a/_redirects
+++ b/_redirects
@@ -1,0 +1,3 @@
+# ks.dev is a convenience redirect to kubescape.io, used in the Kubescape 
+# CLI to reduce the number of characters used.
+https://ks.dev/* https://kubescape.io/:splat 301!


### PR DESCRIPTION
ks.dev is a convenience redirect to kubescape.io, used in the Kubescape CLI to reduce the number of characters used.

(This PR makes the above true.)

Signed-off-by: Craig Box <craigb@armosec.io>