### PR TITLE
fix: typo in relevancy.md for storing filtered sboms

### DIFF
--- a/docs/docs/operator/relevancy.md
+++ b/docs/docs/operator/relevancy.md
@@ -57,7 +57,7 @@ Filtered information are not stored by default, but if enabled, you can view the
 ```
 kubevuln:
   config:
-    storeFilteredSbom: false
+    storeFilteredSboms: false
 ```
 
 ```


### PR DESCRIPTION
The relevancy documentation references storeFilteredSbom, but the actual key in the Helm chart template is storeFilteredSboms (with a trailing s).

Reference: [charts/kubescape-operator/templates/configs/cloudapi-configmap.yaml](https://github.com/kubescape/helm-charts/blob/main/charts/kubescape-operator/templates/configs/cloudapi-configmap.yaml#L36)

This corrects the documentation to match the actual configuration key.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected Helm configuration option name for filtered SBOM storage settings in relevancy documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->