### PR TITLE
doc: multiple output formats in a single scan.

### DIFF
--- a/docs/docs/scanning.md
+++ b/docs/docs/scanning.md
@@ -187,10 +187,16 @@ The default output format for a Kubescape scan is a "pretty-printed" table view.
     kubescape scan --format prometheus
     ```
 
-* HTML
+* HTML:
 
     ```sh
     kubescape scan --format html --output results.html
+    ```
+
+* Multiple output formats in a single scan:
+
+    ```sh
+    kubescape scan --format json,html,prometheus --output result
     ```
 
 * Display all scanned resources (including the resources which passed):


### PR DESCRIPTION
## Description 
Added documentation for generating multiple output formats in a single scan using comma separated values in the `--format` flag.

Related to: https://github.com/kubescape/kubescape/issues/2007

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated output formats documentation with improved HTML output examples.
  * Added new example demonstrating how to request multiple output formats simultaneously in a single scan.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kubescape/kubescape.io/pull/121)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->