### PR TITLE
Docs updated for --push flag image patching

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@
 site/
 devenv
 tmp/*
+
+# Avoid vscode crashing horror by git tracking 10k files
+.venv

--- a/docs/blog/posts/kubescape-3-image-patching/index.md
+++ b/docs/blog/posts/kubescape-3-image-patching/index.md
@@ -124,6 +124,8 @@ We get the following output:
 
 As we can see, we have a new image called **“nginx:1.23-patched”** and the total vulnerabilities has reduced to just 198 from 265!
 
+> **Note on registry pushes:** by default, `kubescape patch` only loads the patched image into your local image store and does **not** push it back to the source registry. If you want it pushed, add the `--push` flag (and authenticate with `--username` / `--password` or your Docker credential store): `kubescape patch -i myregistry/team/app:1.2.3 --push`.
+
 Now, you might wonder — Why weren’t all the vulnerabilities patched and why do we still have 198 vulnerabilities which are not fixed? The answer lies in how image scanning and image patching works.
 
 If you are familiar with any of the popular image scanning software like Grype/Trivy/Docker etc., it lists the following:

--- a/docs/blog/posts/kubescape-3-image-patching/index.md
+++ b/docs/blog/posts/kubescape-3-image-patching/index.md
@@ -124,7 +124,7 @@ We get the following output:
 
 As we can see, we have a new image called **“nginx:1.23-patched”** and the total vulnerabilities has reduced to just 198 from 265!
 
-> **Note on registry pushes:** by default, `kubescape patch` only loads the patched image into your local image store and does **not** push it back to the source registry. If you want it pushed, add the `--push` flag (and authenticate with `--username` / `--password` or your Docker credential store): `kubescape patch -i myregistry/team/app:1.2.3 --push`.
+> **Note on registry pushes:** by default, `kubescape patch` loads the patched image into your local image store and does not push it to the source registry. To push, add the `--push` flag: `kubescape patch -i myregistry/team/app:1.2.3 --push`. For private registries, run `docker login <registry>` first. The BuildKit pull and push path reads credentials from your Docker credential store. The `--username` and `--password` flags authenticate the scan and re-scan steps, not the patch export.
 
 Now, you might wonder — Why weren’t all the vulnerabilities patched and why do we still have 198 vulnerabilities which are not fixed? The answer lies in how image scanning and image patching works.
 

--- a/docs/docs/guides/kubescape-cli/index.md
+++ b/docs/docs/guides/kubescape-cli/index.md
@@ -259,15 +259,17 @@ nginx                   latest            fffffc90d343   3 weeks ago     188MB
 nginx                   latest-patched    c9b68957ce42   3 weeks ago     190MB
 ```
 
-By default, `kubescape patch` loads the patched image into your local Docker image store and does **not** push it back to the source registry. The patched tarball is streamed from BuildKit into `docker load`, so the `docker` CLI must be available on your `PATH` for this default path to work.
+By default, `kubescape patch` loads the patched image into your local Docker image store and does not push it to the source registry. The patched tarball is streamed from BuildKit into `docker load`, so the `docker` CLI must be available on your `PATH`.
 
-To push the patched image to the source registry instead, pass the `--push` flag. Credentials can be supplied via `--username` / `--password`, or are picked up from your Docker credential store:
+To push the patched image to the source registry, pass the `--push` flag:
 
 ```shell
 kubescape patch -i myregistry.example.com/team/app:1.2.3 --push
 ```
 
-When `--push` is used, BuildKit uploads the patched image directly to the registry and does not load it into the local Docker image store.
+For private registries, run `docker login <registry>` before running the command. The BuildKit pull and push path reads registry credentials from your Docker credential store. The `--username` and `--password` flags authenticate the scan and re-scan steps, not the patch export.
+
+With `--push`, BuildKit uploads the patched image to the registry and does not add it to your local Docker image store.
 
 
 ## Conclusion

--- a/docs/docs/guides/kubescape-cli/index.md
+++ b/docs/docs/guides/kubescape-cli/index.md
@@ -259,11 +259,15 @@ nginx                   latest            fffffc90d343   3 weeks ago     188MB
 nginx                   latest-patched    c9b68957ce42   3 weeks ago     190MB
 ```
 
-By default the patched image is only loaded into your local image store and is **not** pushed back to the source registry. If you want Kubescape to also push the patched image to the registry it was pulled from, pass the `--push` flag (and use `--username` / `--password`, or your Docker credential store, to authenticate):
+By default, `kubescape patch` loads the patched image into your local Docker image store and does **not** push it back to the source registry. The patched tarball is streamed from BuildKit into `docker load`, so the `docker` CLI must be available on your `PATH` for this default path to work.
+
+To push the patched image to the source registry instead, pass the `--push` flag. Credentials can be supplied via `--username` / `--password`, or are picked up from your Docker credential store:
 
 ```shell
 kubescape patch -i myregistry.example.com/team/app:1.2.3 --push
 ```
+
+When `--push` is used, BuildKit uploads the patched image directly to the registry and does not load it into the local Docker image store.
 
 
 ## Conclusion

--- a/docs/docs/guides/kubescape-cli/index.md
+++ b/docs/docs/guides/kubescape-cli/index.md
@@ -259,6 +259,12 @@ nginx                   latest            fffffc90d343   3 weeks ago     188MB
 nginx                   latest-patched    c9b68957ce42   3 weeks ago     190MB
 ```
 
+By default the patched image is only loaded into your local image store and is **not** pushed back to the source registry. If you want Kubescape to also push the patched image to the registry it was pulled from, pass the `--push` flag (and use `--username` / `--password`, or your Docker credential store, to authenticate):
+
+```shell
+kubescape patch -i myregistry.example.com/team/app:1.2.3 --push
+```
+
 
 ## Conclusion
 


### PR DESCRIPTION
This is valid only after https://github.com/kubescape/kubescape/pull/2199 lands, please dont merge till then

related - 
https://github.com/kubescape/kubescape/pull/2199 
https://github.com/kubescape/kubescape/discussions/2185

Let me know if there is any place that i am missing to update this change.
Thanks


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified that patched images are loaded into the local image store by default (not pushed)
  * Documented --push behavior and example usage, docker CLI requirement, private registry authentication, and that push uploads directly without adding to local store
  * Clarified that username/password flags apply to scan/re-scan authentication, not patch export

* **Chores**
  * Updated .gitignore to exclude virtual environment directories (.venv)

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kubescape/kubescape.io/pull/122?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->