### PR TITLE
docs: refresh GKE Autopilot node-agent install guide

### DIFF
--- a/docs/docs/integrations/kubescape-integration-with-cloud-providers/running-armokubescape-node-agents-on-gke-autopilot-clusters.md
+++ b/docs/docs/integrations/kubescape-integration-with-cloud-providers/running-armokubescape-node-agents-on-gke-autopilot-clusters.md
@@ -1,10 +1,11 @@
 # Running ARMO/Kubescape Node Agents on GKE Autopilot Clusters
 
-GKE Autopilot has historically restricted workloads that require privileged permissions, such as node agents used for security observability. This made it difficult for tools like ARMO’s Kubescape to deploy their node-level agents on Autopilot clusters.
+GKE Autopilot has historically restricted workloads that require privileged permissions, such as node agents used for security observability. This made it difficult for tools like Kubescape to deploy their node-level agents on Autopilot clusters.
 
 ## Why It Works Now
 
-Starting with recent updates, GKE Autopilot supports a new mechanism for customers to run approved privileged workloads through a feature called **Workload Allowlisting**. This allows cluster operators to enable specific vendor workloads by referencing a vendor-provided allowlist.
+GKE Autopilot supports a mechanism for customers to run approved privileged workloads through a feature called **Workload Allowlisting**. A vendor (here, ARMO, which maintains the Kubescape node-agent allowlist) publishes a Google-approved `WorkloadAllowlist`, and cluster operators enable it by installing an `AllowlistSynchronizer` that references the vendor's allowlist path.
+
 Learn more in the official GKE documentation:
 👉 [Running Autopilot Partner Workloads](https://cloud.google.com/kubernetes-engine/docs/how-to/run-autopilot-partner-workloads)
 
@@ -12,8 +13,22 @@ Learn more in the official GKE documentation:
 
 ## Prerequisites
 
-- **GKE version:** `1.32.2-gke.1652000` or later
-- **Kubescape Helm chart:** `1.27.5` or later
+- **GKE version:** `1.32.2-gke.1652000` or later (required for the `AllowlistSynchronizer` resource).
+- **Kubescape Helm chart:** a version that exposes the `nodeAgent.gke.allowlist` values (`1.27.5` or later). Use a recent chart version.
+
+***
+
+## How allowlist versioning works
+
+Each allowlist is published per **Helm chart minor version**, and its name encodes that minor version:
+
+```
+armo-kubescape-node-agent-<CHART_MINOR>
+```
+
+For example, Helm chart `1.40.x` uses the allowlist `armo-kubescape-node-agent-1.40`; chart `1.41.x` uses `armo-kubescape-node-agent-1.41`, and so on. The `AllowlistSynchronizer` path below uses a wildcard, so it installs **all approved versions** for the workload — you then select the one that matches your chart with the Helm flag in Step 4.
+
+> The allowlist matching your chart minor must already be approved and published by Google. After you install the synchronizer, confirm the expected version appears in `kubectl get WorkloadAllowlist` (Step 3) before deploying.
 
 ***
 
@@ -21,9 +36,12 @@ Learn more in the official GKE documentation:
 
 ### Step 1: Create an AllowlistSynchronizer Resource
 
-First, define an `AllowlistSynchronizer` resource to pull ARMO’s allowlist for node agent workloads.
+Define an `AllowlistSynchronizer` to pull ARMO's allowlist(s) for the node-agent workload. Use the path for the image you run:
 
-Create a file named `kubescape-allowlist.yaml` with the following content:
+- `ARMO/armo-kubescape-node-agent/*` — the public Kubescape node-agent (`quay.io/kubescape/node-agent`).
+- `ARMO/armo-private-node-agent/*` — the ARMO private node-agent (`quay.io/armosec/node-agent`).
+
+Create a file named `kubescape-allowlist.yaml`:
 
 ```yaml
 apiVersion: auto.gke.io/v1
@@ -36,64 +54,62 @@ spec:
   - ARMO/armo-private-node-agent/*
 ```
 
-<br />
-
 ### Step 2: Apply the Allowlist Resource
-
-Apply the YAML using `kubectl`:
 
 ```bash
 kubectl apply -f kubescape-allowlist.yaml
 ```
 
-### Step 3: Validate the Allowlist Sync
+Optionally wait for the synchronizer to finish installing the allowlists:
 
-Confirm that the allowlist has been successfully synced by running:
+```bash
+kubectl wait --for=condition=Ready allowlistsynchronizer/kubescape-allow-list --timeout=60s
+```
+
+### Step 3: Validate the Allowlist Sync
 
 ```bash
 kubectl get WorkloadAllowlist
 ```
 
-You should see a list of synced resources matching the allowlist paths.
+You should see the installed allowlists, including the version that matches your Helm chart minor:
 
 ```
 $ kubectl get WorkloadAllowlist
 NAME                             AGE
-armo-kubescape-node-agent-1.27   37s
-armo-private-node-agent-1.27     37s
+armo-kubescape-node-agent-1.40   37s
+armo-private-node-agent-1.40     37s
 ```
-
-***
 
 ### Step 4: Install Kubescape with Helm
 
-Install or upgrade Kubescape using Helm and set the required allowlist parameters:
+Install or upgrade Kubescape and point the node-agent at the matching allowlist:
 
 ```bash
 helm upgrade --install kubescape kubescape/kubescape-operator \
-... <all the other settings> ...
+  ... <all the other settings> ... \
   --set nodeAgent.gke.allowlist.enabled=true \
-  --set nodeAgent.gke.allowlist.name=armo-kubescape-node-agent-1.27
+  --set nodeAgent.gke.allowlist.name=armo-kubescape-node-agent-<CHART_MINOR>
 ```
 
-Make sure your Helm chart version is `>= 1.27.5`..
+Set `nodeAgent.gke.allowlist.name` to the allowlist whose minor version matches the Helm chart you are installing — e.g. for chart `1.40.x`, use `armo-kubescape-node-agent-1.40`. **ARMO** users running the private node-agent should instead use `armo-private-node-agent-<CHART_MINOR>`.
 
-:exclamation:Note that the `allowlist.name` must include the major version of the Helm chart, like in the example, we are installing the Helm chart version `1.27.5`, therefore, the name is `armo-kubescape-node-agent-1.27`. In case of Helm chart version `1.28.1` the name will be `armo-kubescape-node-agent-1.28` and so on. Also for **ARMO** users, in case you are installing ARMO Private Node-agent, use the name `armo-private-node-agent-1.27`.
+> Enabling `nodeAgent.gke.allowlist.enabled` adds the `cloud.google.com/matching-allowlist` label to the node-agent pod, which is how GKE matches the workload to the named allowlist.
 
-***
-
-### Step 5: Verify Node Agent Pod is Running
-
-Check that the node agent pod is successfully running:
+### Step 5: Verify the Node Agent Pod is Running
 
 ```bash
 kubectl get pods -n kubescape
 ```
 
-Look for a pod with a name similar to `node-agent-*` and ensure it has `STATUS: Running`.
+Look for a pod named `node-agent-*` with `STATUS: Running`.
 
 ***
 
+## Using private (mirrored) images
+
+If you mirror the node-agent image into a private registry, reference it by SHA-256 **digest** that matches the public image. The allowlist publishes the accepted digests (`containerImageDigests`); see [Run Autopilot partner workloads — private image mirrors](https://cloud.google.com/kubernetes-engine/docs/how-to/run-autopilot-partner-workloads).
+
 ## 🎉 You're Done!
 
-Your GKE Autopilot cluster is now running ARMO/Kubescape's node agents securely and in compliance with GKE's partner workload policies.
+Your GKE Autopilot cluster is now running Kubescape's node agents in compliance with GKE's partner workload policies.


### PR DESCRIPTION
## What
Refreshes the existing [Running ARMO/Kubescape Node Agents on GKE Autopilot Clusters](https://kubescape.io/docs/integrations/kubescape-integration-with-cloud-providers/running-armokubescape-node-agents-on-gke-autopilot-clusters/) guide, which was pinned to chart version 1.27.

## Why
The allowlist name must match the installed Helm chart's **minor** version. The old guide hardcoded `1.27`, called it the "major version", and didn't explain how to pick the right version for newer charts.

## Changes
- Add a **How allowlist versioning works** section; use `<CHART_MINOR>` and explain the `armo-<flavor>-node-agent-<minor>` naming, with a current (1.40) example.
- Fix "major version" → "minor version" wording.
- Add an `AllowlistSynchronizer` readiness check (`kubectl wait --for=condition=Ready`).
- Clarify the public Kubescape (`quay.io/kubescape`) vs ARMO-private (`quay.io/armosec`) allowlist paths.
- Note that `nodeAgent.gke.allowlist.enabled` adds the `cloud.google.com/matching-allowlist` label.
- Add a short private image-mirror (digest) note.

No behavioral/product change — documentation only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated GKE Autopilot integration guide with comprehensive "Workload Allowlisting" workflow documentation for node agents.
  * Added minimum GKE version and Helm chart version requirements to prerequisites.
  * Clarified allowlist naming conventions and version matching guidance.
  * Revised deployment instructions with updated configuration examples and validation steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->