### PR TITLE
docs: add GitLab CI integration page

### DIFF
--- a/docs/docs/integrations/gitlab.md
+++ b/docs/docs/integrations/gitlab.md
@@ -1,0 +1,109 @@
+# Integrating with GitLab CI/CD
+
+Use GitLab CI/CD to scan Kubernetes manifests, Helm charts, or other workload configuration files with Kubescape whenever a merge request is opened or the default branch is updated. The examples below install the Kubescape CLI in the job, run a scan, and publish JUnit results back to GitLab.
+
+## Prerequisites
+
+* A GitLab project with GitLab CI/CD enabled.
+* A GitLab Runner with network access to GitHub, so it can download the Kubescape install script.
+* Kubernetes manifest, Helm chart, or other workload files in the repository.
+
+## Basic pipeline
+
+Create a `.gitlab-ci.yml` file in the root of your repository:
+
+```yaml
+stages:
+  - scan
+
+kubescape:
+  stage: scan
+  image: alpine:latest
+  before_script:
+    - apk add --no-cache bash curl gcompat
+    - curl -s https://raw.githubusercontent.com/kubescape/kubescape/master/install.sh | /bin/bash
+    - export PATH="$PATH:$HOME/.kubescape/bin"
+  script:
+    - kubescape scan . --format junit --output results.xml
+  artifacts:
+    when: always
+    reports:
+      junit: results.xml
+    paths:
+      - results.xml
+    expire_in: 30 days
+  rules:
+    - if: $CI_PIPELINE_SOURCE == "merge_request_event"
+    - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH
+```
+
+The job scans the current repository path and uploads `results.xml` as a GitLab test report.
+
+## Add a security gate
+
+Use `--compliance-threshold` when you want the job to fail if the compliance score is below a required percentage. The threshold applies to framework and control scans, and to resource or control views.
+
+```yaml
+stages:
+  - scan
+
+kubescape:
+  stage: scan
+  image: alpine:latest
+  before_script:
+    - apk add --no-cache bash curl gcompat
+    - curl -s https://raw.githubusercontent.com/kubescape/kubescape/master/install.sh | /bin/bash
+    - export PATH="$PATH:$HOME/.kubescape/bin"
+  script:
+    - kubescape scan framework nsa . --format junit --output results.xml --compliance-threshold 80
+  artifacts:
+    when: always
+    reports:
+      junit: results.xml
+    paths:
+      - results.xml
+    expire_in: 30 days
+  rules:
+    - if: $CI_PIPELINE_SOURCE == "merge_request_event"
+    - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH
+```
+
+This job fails when the NSA framework compliance score is lower than 80%.
+
+## Scan a specific framework
+
+To scan against a specific compliance framework, pass the framework name to `kubescape scan framework`:
+
+```yaml
+script:
+  - kubescape scan framework nsa . --format junit --output results.xml
+```
+
+Common frameworks include `nsa`, `mitre`, and `cis-v1.23-t1.0.1`. Run `kubescape list frameworks` for the complete list supported by your installed Kubescape version.
+
+## Troubleshooting
+
+### `kubescape: command not found`
+
+Make sure the Kubescape binary directory is added to `PATH` before running the scan:
+
+```yaml
+before_script:
+  - curl -s https://raw.githubusercontent.com/kubescape/kubescape/master/install.sh | /bin/bash
+  - export PATH="$PATH:$HOME/.kubescape/bin"
+```
+
+### The threshold does not fail the job
+
+The default `kubescape scan [path]` command uses the security view. For score-based gates, use a framework scan, a control scan, or `--view resource`/`--view control`.
+
+```sh
+kubescape scan framework nsa . --compliance-threshold 80
+kubescape scan --view resource . --compliance-threshold 80
+```
+
+## Further reading
+
+* [Scanning your environment](../scanning.md)
+* [Frameworks](../frameworks-and-controls/frameworks.md)
+* [GitLab CI/CD pipelines](https://docs.gitlab.com/ci/pipelines/)

--- a/docs/docs/integrations/index.md
+++ b/docs/docs/integrations/index.md
@@ -1,0 +1,8 @@
+# Integrations
+
+Kubescape can run in developer tools and CI/CD systems so security feedback is available before workloads are deployed.
+
+* [GitHub](github.md)
+* [GitLab CI/CD](gitlab.md)
+* [Lens](lens.md)
+* [VS Code](vscode.md)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -75,6 +75,7 @@ nav:
         - Integrations:
             - 'Overview': 'docs/integrations/index.md'
             - 'GitHub': 'docs/integrations/github.md'
+            - 'GitLab CI/CD': 'docs/integrations/gitlab.md'
             - 'Lens': 'docs/integrations/lens.md'
             - 'VS Code': 'docs/integrations/vscode.md'
         - Frameworks and Controls:


### PR DESCRIPTION
## Summary
- add a GitLab CI/CD integration page at `/docs/integrations/gitlab/`
- add the GitLab page to the Integrations navigation
- populate the Integrations overview so GitLab is discoverable from the section landing page

## Broken link context
The `kubescape/kubescape` README currently links to `https://kubescape.io/docs/integrations/gitlab/` from its Integrations table, but that route returns 404 because the website repository does not publish a GitLab integration page. This PR adds the missing website route so the existing README link works after deployment.

## Root cause
The website repository did not contain `docs/docs/integrations/gitlab.md`, and `mkdocs.yml` did not include GitLab under the Integrations nav.

## Validation
- `uv run --python 3.10 --with-requirements requirements.txt mkdocs build`
- Netlify deploy preview returns 200 for `/docs/integrations/gitlab/`
- `uv run --python 3.10 --with-requirements requirements.txt mkdocs build --strict` reaches the new page but still fails because of 27 pre-existing unrelated docs warnings.