### PR TITLE
Refresh GKE Autopilot node-agent install guide

### DIFF
--- a/docs/docs/integrations/kubescape-integration-with-cloud-providers/running-armokubescape-node-agents-on-gke-autopilot-clusters.md
+++ b/docs/docs/integrations/kubescape-integration-with-cloud-providers/running-armokubescape-node-agents-on-gke-autopilot-clusters.md
@@ -83,18 +83,24 @@ armo-private-node-agent-1.40     37s
 
 ### Step 4: Install Kubescape with Helm
 
-Install or upgrade Kubescape and point the node-agent at the matching allowlist:
+Enable the GKE Autopilot allowlist when you install or upgrade. Recent chart versions set
+`nodeAgent.gke.allowlist.name` to the correct allowlist for that chart version **by default**, so you
+normally only need to enable the feature:
 
 ```bash
 helm upgrade --install kubescape kubescape/kubescape-operator \
   ... <all the other settings> ... \
-  --set nodeAgent.gke.allowlist.enabled=true \
-  --set nodeAgent.gke.allowlist.name=armo-kubescape-node-agent-<CHART_MINOR>
+  --set nodeAgent.gke.allowlist.enabled=true
 ```
 
-Set `nodeAgent.gke.allowlist.name` to the allowlist whose minor version matches the Helm chart you are installing — e.g. for chart `1.40.x`, use `armo-kubescape-node-agent-1.40`. **ARMO** users running the private node-agent should instead use `armo-private-node-agent-<CHART_MINOR>`.
+> Enabling the feature adds the `cloud.google.com/matching-allowlist` label to the node-agent pod, which
+> is how GKE matches the workload to the allowlist.
 
-> Enabling `nodeAgent.gke.allowlist.enabled` adds the `cloud.google.com/matching-allowlist` label to the node-agent pod, which is how GKE matches the workload to the named allowlist.
+**Overriding the allowlist name** (older charts, or to pin a specific version): set
+`nodeAgent.gke.allowlist.name` to the exact name shown in Step 3 that matches your chart — for example
+`armo-kubescape-node-agent-1.40-v2` (public Kubescape node-agent). **ARMO** users running the private
+node-agent (`quay.io/armosec/node-agent`) should use `armo-private-node-agent-…` instead. The name must
+match an allowlist installed in the cluster (Step 3).
 
 ### Step 5: Verify the Node Agent Pod is Running
 
@@ -109,6 +115,25 @@ Look for a pod named `node-agent-*` with `STATUS: Running`.
 ## Using private (mirrored) images
 
 If you mirror the node-agent image into a private registry, reference it by SHA-256 **digest** that matches the public image. The allowlist publishes the accepted digests (`containerImageDigests`); see [Run Autopilot partner workloads — private image mirrors](https://cloud.google.com/kubernetes-engine/docs/how-to/run-autopilot-partner-workloads).
+
+## Troubleshooting
+
+**Node-agent pod/DaemonSet rejected with a GKE Warden error** (`Workload Mismatches Found` or
+`does not contain all required exemptions`): the workload doesn't match the allowlist it was pointed at.
+Common causes:
+
+- **Wrong or missing version.** The allowlist named on the pod isn't installed in the cluster. Re-check
+  Step 3 (`kubectl get WorkloadAllowlist`) and make sure the name matches an installed allowlist for
+  your chart version. If it isn't there yet, the approved allowlist may still be rolling out to your
+  region (Google rolls out gradually, up to ~7 business days after approval).
+- **`AllowlistSynchronizer` not `Ready`.** Run `kubectl get allowlistsynchronizer` — a `SyncError`
+  usually means one listed path isn't published yet. Keep only paths you use.
+- **The node-agent genuinely changed.** If you run a chart version newer than the latest approved
+  allowlist, its node-agent may require settings the allowlist doesn't cover yet. Use a chart version
+  whose matching allowlist is approved.
+
+The node-agent runs one DaemonSet per node group (the autoscaler sizes them per instance type), so you
+may see several `node-agent-*` pods — this is expected.
 
 ## 🎉 You're Done!
 

--- a/docs/docs/integrations/kubescape-integration-with-cloud-providers/running-armokubescape-node-agents-on-gke-autopilot-clusters.md
+++ b/docs/docs/integrations/kubescape-integration-with-cloud-providers/running-armokubescape-node-agents-on-gke-autopilot-clusters.md
@@ -26,7 +26,7 @@ Each allowlist is published per **Helm chart minor version**, and its name encod
 armo-kubescape-node-agent-<CHART_MINOR>
 ```
 
-For example, Helm chart `1.40.x` uses the allowlist `armo-kubescape-node-agent-1.40`; chart `1.41.x` uses `armo-kubescape-node-agent-1.41`, and so on. The `AllowlistSynchronizer` path below uses a wildcard, so it installs **all approved versions** for the workload — you then select the one that matches your chart with the Helm flag in Step 4.
+For example, Helm chart `1.40.x` uses the allowlist `armo-kubescape-node-agent-1.40-v2`; chart `1.41.x` uses `armo-kubescape-node-agent-1.41`, and so on. A revision suffix such as `-v2` is appended when an allowlist is superseded — use the exact name reported by `kubectl get WorkloadAllowlist` (Step 3). The `AllowlistSynchronizer` path below uses a wildcard, so it installs **all approved versions** for the workload — you then select the one that matches your chart with the Helm flag in Step 4.
 
 > The allowlist matching your chart minor must already be approved and published by Google. After you install the synchronizer, confirm the expected version appears in `kubectl get WorkloadAllowlist` (Step 3) before deploying.
 
@@ -76,10 +76,14 @@ You should see the installed allowlists, including the version that matches your
 
 ```
 $ kubectl get WorkloadAllowlist
-NAME                             AGE
-armo-kubescape-node-agent-1.40   37s
-armo-private-node-agent-1.40     37s
+NAME                                AGE
+armo-kubescape-node-agent-1.40-v2   37s
+armo-private-node-agent-1.40-v2     37s
 ```
+
+Use the exact name shown here when overriding the allowlist name (Step 4). A revision suffix such as
+`-v2` is appended when an allowlist is superseded, so match whatever `kubectl get WorkloadAllowlist`
+reports.
 
 ### Step 4: Install Kubescape with Helm
 


### PR DESCRIPTION
Completes the guide for running the Kubescape/ARMO node-agent on GKE Autopilot via the AllowlistSynchronizer + `nodeAgent.gke.allowlist` flow.

Covers: why it works, prerequisites, allowlist paths (public Kubescape + ARMO private), versioning, the AllowlistSynchronizer, validation, Helm install (enable the allowlist; chart sets the correct name by default), private mirrored images, and troubleshooting (Warden mismatch, sync errors, rollout timing, autoscaler DaemonSets). Validated end-to-end on a live Autopilot cluster.

AI-skills: armosec-shared-rules:writing-docs,schedule,loop | cmds: /model,/login