### PR TITLE
docs(accepting-risk): document SecurityException and ClusterSecurityException resources

### DIFF
--- a/docs/docs/accepting-risk.md
+++ b/docs/docs/accepting-risk.md
@@ -69,10 +69,7 @@ Under `spec`:
 
 At least one of `posture` or `vulnerabilities` must be set.
 
-`action` can be:
-
-- `ignore` — suppress the finding; the resource is reported as passed with exceptions and no longer counts against the score.
-- `alert_only` — keep the finding in the results, but mark it as an accepted exception rather than removing it.
+`action` can be `ignore` or `alert_only`. In a CLI posture scan, a matched resource is reported as passed with exceptions for either value, and it is excluded from the control's failed-resource count and compliance score. The value you choose is preserved in the scan results, which is where the two currently differ.
 
 ### Matching resources
 

--- a/docs/docs/accepting-risk.md
+++ b/docs/docs/accepting-risk.md
@@ -8,6 +8,92 @@ Control failures cannot account for all situations.  What is acceptable in one e
 
 **Exceptions** are the method for excluding failed resources from affecting the risk score. For example, a control may count the number of resources that have `cluster-admin` role assigned. Any number above 0 will be considered a failure. Using exceptions, you note that you have considered each resource and deemed it OK. Then, you know that if you ever see this control failure, it is something that warrants investigation.
 
+Exceptions can be supplied in two ways: an exceptions file passed to the CLI (described below), or `SecurityException` / `ClusterSecurityException` resources stored in the cluster (described in [Accepting risk with in-cluster resources](#accepting-risk-with-in-cluster-resources)).
+
+## Accepting risk with in-cluster resources
+
+Exceptions can also be stored in the cluster as custom resources, instead of or alongside an exceptions file. This suits GitOps workflows, where the exceptions live in Git with the rest of your manifests. The exceptions file described in the following sections continues to work unchanged.
+
+There are two kinds, both served at `kubescape.io/v1beta1`:
+
+- `SecurityException` (namespaced, short name `se`) — applies within its own namespace.
+- `ClusterSecurityException` (cluster-scoped, short name `cse`) — can apply across namespaces and adds a `namespaceSelector`.
+
+When you scan a cluster, Kubescape reads these resources automatically; there is no extra flag. A single resource can hold posture exceptions, vulnerability exceptions, or both. The posture part is what affects framework and control scans, and is what this section covers.
+
+### Example
+
+This `SecurityException` stops `Deployment/nginx` in the `production` namespace from failing control `C-0034`:
+
+```yaml
+apiVersion: kubescape.io/v1beta1
+kind: SecurityException
+metadata:
+  name: except-c0034-nginx
+  namespace: production
+spec:
+  reason: "Service account mapping reviewed and accepted for nginx"
+  author: "platform-team"
+  posture:
+    - controlID: C-0034
+      action: ignore
+  match:
+    resources:
+      - kind: Deployment
+        name: nginx
+```
+
+Apply it, then scan the cluster as usual:
+
+```sh
+kubectl apply -f except-c0034-nginx.yaml
+kubescape scan framework nsa --include-namespaces production
+```
+
+With the exception in place, `C-0034` on `Deployment/nginx` is reported as passed with exceptions instead of failed. Kubescape also records a Kubernetes Event on the `SecurityException` resource, which you can view with:
+
+```sh
+kubectl describe securityexception except-c0034-nginx -n production
+```
+
+### Fields
+
+Under `spec`:
+
+- `reason` — free-text explanation, shown in `kubectl get se`.
+- `author` — free-text owner of the exception.
+- `expiresAt` — optional RFC 3339 timestamp. It is checked at scan time: once it has passed, the exception is ignored and the finding is reported again. It is not enforced by the resource itself, only during a scan.
+- `match` — which resources the exception applies to (see [Matching resources](#matching-resources)).
+- `posture` — a list of `{ controlID, action, frameworkName }` entries. `controlID` and `action` are required; `frameworkName` optionally limits the exception to a single framework.
+- `vulnerabilities` — vulnerability exceptions, handled by the in-cluster vulnerability scanner (kubevuln). They do not affect posture scans.
+
+At least one of `posture` or `vulnerabilities` must be set.
+
+`action` can be:
+
+- `ignore` — suppress the finding; the resource is reported as passed with exceptions and no longer counts against the score.
+- `alert_only` — keep the finding in the results, but mark it as an accepted exception rather than removing it.
+
+### Matching resources
+
+`match` supports:
+
+- `resources` — a list of `{ kind, name, apiGroup }` entries. `kind` is required; `name` and `apiGroup` are optional.
+- `objectSelector` — a standard Kubernetes label selector matched against the workload's labels.
+- `namespaceSelector` — (`ClusterSecurityException` only) a label selector matched against namespace labels.
+
+Multiple `resources` entries are combined with a logical OR — any one match is enough. If you also set an `objectSelector`, it is combined with the resource match using AND, so a workload has to satisfy both. If `match` is empty, a `SecurityException` applies to its whole namespace and a `ClusterSecurityException` applies cluster-wide.
+
+### Precedence over the exceptions file and cloud exceptions
+
+If the same control and resource is covered by both a file or cloud exception and an in-cluster resource, the file or cloud exception takes precedence and the overlapping in-cluster entry is skipped. Any non-overlapping parts of the in-cluster exception still apply.
+
+### Enabling the in-cluster components
+
+The Kubescape CLI reads these resources using whatever access your kubeconfig has. The in-cluster components (operator and kubevuln) read them only when the Helm value `capabilities.riskAcceptance` is set to `enable`; it defaults to `disable`. Enabling it also grants the access needed to resolve `objectSelector` and `namespaceSelector` labels, and lets the operator trigger a re-scan when an exception is added, changed, or removed.
+
+For the full design, see the [SecurityException design document](https://github.com/kubescape/kubevuln/blob/main/docs/security-exception-design.md).
+
 ## Scanning with an exceptions file
 
 Use the `--exceptions` flag when performing a scan:


### PR DESCRIPTION
## What

Adds a section to the "Accepting risk" page documenting the in-cluster SecurityException and ClusterSecurityException resources, alongside the existing exceptions-file documentation. The existing file-based content is left unchanged.

The new section covers:

- The two kinds: SecurityException (namespaced) and ClusterSecurityException (cluster-scoped), both served at kubescape.io/v1beta1
- A worked posture example that excepts control C-0034 on a Deployment
- The spec fields (reason, author, expiresAt, match, posture, vulnerabilities) and the action values (ignore, alert_only)
- How match selectors combine, and precedence over file and cloud exceptions
- The capabilities.riskAcceptance Helm value that the in-cluster components require

## Why

The CRD-based exception mechanism shipped across the Kubescape components, but the docs site still described only the exceptions file and cloud options. This adds the missing documentation so the feature is discoverable.

Tracking issue: https://github.com/kubescape/kubescape/issues/1982


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for accepting risk through in-cluster Kubernetes resources.
  * Documented supported exception resources, fields, selectors, and matching behavior.
  * Clarified precedence between file-based, cloud-based, and in-cluster exceptions.
  * Documented configuration requirements, access considerations, and automatic rescans when exceptions change.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->