### PR TITLE
SBOB-migration addon -> switch to containerprofile

### DIFF
--- a/docs/docs/operator/bill-of-behavior/index.md
+++ b/docs/docs/operator/bill-of-behavior/index.md
@@ -17,15 +17,9 @@ We are working on providing `validation tests` for common CNCF projects to make 
 
 ## How Kubescape is a reference implementation
 
-Kubescape implements the SBOB end to end, using eBPF to observe workloads at the Linux ABI and Kubernetes custom resources to store the declaration, it allows signing the YAMLs and it detects tampering.[^migration]
+Kubescape implements the SBOB end to end, using eBPF to observe workloads at the Linux ABI and Kubernetes custom resources to store the declaration, it allows signing the YAMLs and it detects tampering.
 
 
-[^migration]: The first implementation currently relies on the CRDs `ApplicationProfile`
-    and `NetworkNeighborhood`, but we will migrate them to `ContainerProfile` asap.
-    The functionality itself will not be affected.
-
-    Currently, you need to apply the CRD to the cluster before the workload and ensure
-    the labels are correct.
 
 ## Beyond learned profiles, a note on Usability
 

--- a/docs/docs/operator/bill-of-behavior/quickstart.md
+++ b/docs/docs/operator/bill-of-behavior/quickstart.md
@@ -23,7 +23,7 @@ Our chain continues to connect to postgres via `psql` and to exfiltrate the `bas
 You need the `Kubescape Node-Agent` and `Kubescape Storage` component
 
 ```bash
-CHART=https://github.com/k8sstormcenter/helm-charts/releases/download/kubescape-operator-1.40.3-sbob-rc4.1/kubescape-operator-1.40.3-sbob-rc4.1.tgz
+CHART=https://github.com/k8sstormcenter/helm-charts/releases/download/kubescape-operator-1.40.3-sbob-rc4.2/kubescape-operator-1.40.3-sbob-rc4.2.tgz
 helm install kubescape "$CHART" \
   -n kubescape --create-namespace \
   --set capabilities.runtimeObservability=enable \
@@ -60,6 +60,15 @@ spec:
 
 The profiles are **user-defined**, so detection is instantly live with no learning period. 
 
+!!! "Wait for storage before applying profiles"
+    as the `ContainerProfile` is served by the Kubescape **storage** aggregated API-server
+
+    ```bash
+    kubectl -n kubescape rollout status deploy/storage --timeout=180s
+    kubectl wait --for=condition=Available --timeout=180s \
+      apiservices/v1beta1.spdx.softwarecomposition.kubescape.io
+    ```
+
 First, deploy one `ContainerProfile` per workload for the log4j-demo:
 
 ```bash
@@ -68,6 +77,8 @@ BASE=https://raw.githubusercontent.com/k8sstormcenter/bob/main/_artifacts/log4j-
 for w in backend frontend observer postgres; do
   kubectl apply -f "$BASE/cp-chain-$w.yaml"
 done
+# verify they actually landed (4 profiles):
+kubectl get containerprofiles -n log4j-poc
 ```
 
 Two sections of the java-backend's SBOB are 
@@ -226,16 +237,7 @@ kubectl delete ns log4j-poc attacker-ns      # clean up
 The JNDI string needs to resolve an outbound LDAP + HTTP to fetch the exploit class for
 Log4j 
 
-**1. R0011 ships disabled.** Enable it in the installed rules:
-
-```bash
-kubectl -n kubescape patch rules.kubescape.io default-rules --type=json \
-  -p "$(kubectl -n kubescape get rules.kubescape.io default-rules -o json \
-        | jq -c '[.spec.rules | to_entries[] | select(.value.id=="R0011")
-                 | {op:"replace", path:"/spec/rules/\(.key)/enabled", value:true}]')"
-```
-
-**2. R0011 skips private targets.** The in-cluster attacker is a ClusterIP (RFC-1918), so put the attacker on an **external/public** host
+**R0011 skips private targets.** The in-cluster attacker is a ClusterIP (RFC-1918), so put the attacker on an **external/public** host
  and point the JNDI there — the demo
 attacker image has an ENV var `CODEBASE_HOST`, so it runs anywhere:
 

--- a/docs/docs/operator/bill-of-behavior/quickstart.md
+++ b/docs/docs/operator/bill-of-behavior/quickstart.md
@@ -60,16 +60,18 @@ spec:
 
 The profiles are **user-defined**, so detection is instantly live with no learning period. 
 
-!!! "Wait for storage before applying profiles"
+!!! warning "Wait for storage before applying profiles"
     as the `ContainerProfile` is served by the Kubescape **storage** aggregated API-server
 
-    ```bash
-    kubectl -n kubescape rollout status deploy/storage --timeout=180s
-    kubectl wait --for=condition=Available --timeout=180s \
-      apiservices/v1beta1.spdx.softwarecomposition.kubescape.io
-    ```
+Gate on storage being ready first:
 
-First, deploy one `ContainerProfile` per workload for the log4j-demo:
+```bash
+kubectl -n kubescape rollout status deploy/storage --timeout=180s
+kubectl wait --for=condition=Available --timeout=180s \
+  apiservices/v1beta1.spdx.softwarecomposition.kubescape.io
+```
+
+Then deploy one `ContainerProfile` per workload for the log4j-demo:
 
 ```bash
 kubectl create namespace log4j-poc
@@ -111,7 +113,7 @@ will not be detected as anomaly.
 
  
 !!! tip "Allowlisting obvious parts of attack for demo"
-    For showcasing various features, we pretend the attacker uses binaries that the app was intended to use. A real java implementation 
+    For showcasing various features, we pretend the attacker uses binaries that are marked as `intended for the application`. A real java implementation 
     would not use `psql`. 
 
 !!! tip "NEW: Symlinks resolve and list the real binary"

--- a/docs/docs/operator/bill-of-behavior/quickstart.md
+++ b/docs/docs/operator/bill-of-behavior/quickstart.md
@@ -23,7 +23,7 @@ Our chain continues to connect to postgres via `psql` and to exfiltrate the `bas
 You need the `Kubescape Node-Agent` and `Kubescape Storage` component
 
 ```bash
-CHART=https://github.com/k8sstormcenter/helm-charts/releases/download/kubescape-operator-1.40.3-sbob-rc3.1/kubescape-operator-1.40.3-sbob-rc3.1.tgz
+CHART=https://github.com/k8sstormcenter/helm-charts/releases/download/kubescape-operator-1.40.3-sbob-rc4.1/kubescape-operator-1.40.3-sbob-rc4.1.tgz
 helm install kubescape "$CHART" \
   -n kubescape --create-namespace \
   --set capabilities.runtimeObservability=enable \
@@ -37,71 +37,64 @@ So **R0005** (DNS exfil) and **R0011** (Unexpected egress) need an external conn
 on a public location and read/adapt the CEL rules to understand which rules fire exactly when.
 
 
-The general pattern is to ensure that sbobs of `your-sbob-name` exist and to bind
-them via labels on each pod[^migration]
+The general pattern is to ensure that a sbob of `your-sbob-name` exists and to bind
+it via a label on each pod
 
 
-[^migration]: The first implementation currently relies on the CRDs `ApplicationProfile`
-    and `NetworkNeighborhood`, but we will migrate them to `ContainerProfile` asap.
-    The functionality itself will not be affected.
 
-    Currently, you need to apply the CRD to the cluster **before** the workload and ensure
-    the labels are correct.
 
 ```yaml
 spec:
   template:
     metadata:
       labels:
-        kubescape.io/user-defined-profile: your-sbob-name    
-        kubescape.io/user-defined-network: your-sbob-name    
+        kubescape.io/user-defined-profile: your-sbob-name
 ```
 
 !!! info "Which build is this"
-    `sbob-rc3` is the release candidate that ships the Bill of Behavior features (wildcards, signing,
-    tamper detection), watch for announcements when it becomes GA.
+    `sbob-rc4` is the release candidate that ships the Bill of Behavior features
+    (wildcards, signing, tamper detection) on the unified `ContainerProfile`.
+    Watch for announcements when it becomes GA.
 
 ## 2. Apply the Bill of Behavior — *before* the app
 
 The profiles are **user-defined**, so detection is instantly live with no learning period. 
 
-First, deploy the `user-defined-profile` and `user-defined-network` for the log4j-demo:
+First, deploy one `ContainerProfile` per workload for the log4j-demo:
 
 ```bash
 kubectl create namespace log4j-poc
 BASE=https://raw.githubusercontent.com/k8sstormcenter/bob/main/_artifacts/log4j-sbobs
 for w in backend frontend observer postgres; do
-  kubectl apply -f "$BASE/ap-chain-$w.yaml" -f "$BASE/nn-chain-$w.yaml"
+  kubectl apply -f "$BASE/cp-chain-$w.yaml"
 done
 ```
 
-Two sections of the java-backend's SBOB are worth highlighting:
+Two sections of the java-backend's SBOB are 
+worth highlighting:
 
 ```yaml
-# ap-chain-backend.yaml 
-execs:
-- { path: /opt/java/openjdk/bin/java, args: ["java", "-jar", "/app/app.jar"] }
-- { path: /usr/bin/curl }
-- { path: /usr/bin/psql,                   
-          args: ["/usr/bin/psql"] }  # symlink
-#  New: node-agent sees the *resolved* path from a symlink
-- { path: /usr/lib/postgresql/18/bin/psql, 
-          args: ["/usr/lib/postgresql/18/bin/psql", "⋯⋯"] }
-#  New: wildcard ⋯⋯ allows any psql arguments.
+# cp-chain-backend.yaml 
+kind: ContainerProfile
+spec:
+  matchLabels: { app: chain-backend }   
+  execs:
+  - { path: /opt/java/openjdk/bin/java, args:
+     ["/opt/java/openjdk/bin/java", "-jar", "/app/app.jar"] }
+  - { path: /usr/bin/curl }
+  - { path: /usr/bin/psql,              args: 
+     ["/usr/bin/psql"] }  # symlink
+  #  New: node-agent sees the *resolved* path from a symlink
+  - { path: /usr/lib/postgresql/18/bin/psql, 
+     args: ["/usr/lib/postgresql/18/bin/psql", "⋯⋯"] }
+  #  New: wildcard ⋯⋯ allows any psql arguments.
+  ingress:
+  - from: { app: chain-frontend }   ports: [ TCP/8080 ]   # incoming from nginx
+  egress:
+  - to: kube-dns                    ports: [ UDP/53, TCP/53 ]
+  - to: { app: chain-postgres }     ports: [ TCP/5432 ]   # java-app intended to connect to DB
 ```
 To showcase the symlink resolution, we make java use `psql` for its connection to the DB.
-
-
-
-```yaml
-# nn-chain-backend.yaml — allowed network for java
-ingress:
-- from: { app: chain-frontend }   ports: [ TCP/8080 ]   #incoming from nginx
-egress:
-- to: kube-dns                    ports: [ UDP/53, TCP/53 ]
-- to: { app: chain-postgres }     ports: [ TCP/5432 ]   # java-app intended to connect to DB
-```
-
 Egress to postgres is *allowed* — this java really does query a database. This means, the connection via network from java-backend to postgres
 will not be detected as anomaly. 
 
@@ -129,7 +122,7 @@ kubectl -n kube-system rollout restart deploy/coredns
 
 ## 4. Deploy the vulnerable app + the attacker
 
-Bring up the whole `log4j-poc`[^scenarios], all pods labelled `user-defined-profile/network` to bind the profiles from Step 2.  
+Bring up the whole `log4j-poc`[^scenarios], all pods carry the single `kubescape.io/user-defined-profile: chain-<workload>` label to bind the ContainerProfile from Step 2.  
 The manifest also includes the attacker: a marshalsec LDAP server and a class-file HTTP server.
 
 [^scenarios]: 

--- a/docs/docs/operator/bill-of-behavior/signing-and-tamper.md
+++ b/docs/docs/operator/bill-of-behavior/signing-and-tamper.md
@@ -28,11 +28,11 @@ The signature travels **with** the object, as an annotation.
 
 ## Try it yourself
 
-Prerequisites: a cluster with Kubescape **sbob-rc3** installed (see the
+Prerequisites: a cluster with Kubescape **sbob-rc4** installed (see the
 [quickstart install](quickstart.md)), plus `kubectl`, `docker`, `jq`, and `yq`. 
 
 ```bash
-export SIGN_OBJECT="ghcr.io/k8sstormcenter/sign-object:v0.0.3@sha256:f3d4e321fa62e0a4ca421ba59a3fce3f2ff88714aaf87a7d160322cb8ec2f92b"
+export SIGN_OBJECT="ghcr.io/k8sstormcenter/sign-object:sbob-rc4@sha256:baa78f7c9e2692146d9148760557839a60da4a4bffd224ff000a8d70b1dc00a8"
 sign_object() { docker run --rm -v "$PWD:/work" "$SIGN_OBJECT" "$@"; }
 mkdir -p sbob-signing && cd sbob-signing
 ```
@@ -48,16 +48,15 @@ sign_object generate-keypair --output cosign.key
 ```bash
 cat > my-profile.yaml <<'EOF'
 apiVersion: spdx.softwarecomposition.kubescape.io/v1beta1
-kind: ApplicationProfile
+kind: ContainerProfile
 metadata:
   name: signed-demo
   namespace: sig-demo
 spec:
   architectures: ["amd64"]
-  containers:
-  - name: app
-    execs:
-    - { path: /bin/sleep, args: ["/bin/sleep", "infinity"] }
+  matchLabels: { app: signed-demo }
+  execs:
+  - { path: /bin/sleep, args: ["/bin/sleep", "infinity"] }
 EOF
 ```
 
@@ -65,7 +64,7 @@ EOF
 
 ```bash
 sign_object sign --file my-profile.yaml --output my-profile.signed.yaml \
-  --key cosign.key --type applicationprofile
+  --key cosign.key --type containerprofile
 ```
 
 **4. Apply the signed profile first, then a workload that references it** by label.
@@ -86,7 +85,6 @@ spec:
       labels:
         app: signed-demo
         kubescape.io/user-defined-profile: signed-demo
-        kubescape.io/user-defined-network: signed-demo
     spec:
       containers:
       - { name: app, image: busybox:1.36, command: ["/bin/sleep", "infinity"] }
@@ -103,8 +101,8 @@ kubectl -n kubescape logs -l app=node-agent --tail=-1 | grep -c '"RuleID":"R1016
 **5. Tamper.** Add `/bin/sh` to the signed profile, keeping the old signature. Any in-place edit works — `kubectl patch`, `edit`, `apply`, `replace`, or delete + re-apply. The signature no longer matches the spec:
 
 ```bash
-kubectl -n sig-demo patch applicationprofile signed-demo --type=json \
-  -p '[{"op":"add","path":"/spec/containers/0/execs/-","value":{"path":"/bin/sh","args":["/bin/sh"]}}]'
+kubectl -n sig-demo patch containerprofile signed-demo --type=json \
+  -p '[{"op":"add","path":"/spec/execs/-","value":{"path":"/bin/sh","args":["/bin/sh"]}}]'
 ```
 
 


### PR DESCRIPTION
Update the installation instructions and update the remote links so the demo SBOBs are CPs, no longer AP +NN

this relates to issue https://github.com/kubescape/node-agent/issues/862
Should only be merged if we agree on migrating the AP/NNs to containerprofiles, see node-agent [PR 864](https://github.com/kubescape/node-agent/pull/864) 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Bill of Behavior quickstart instructions to use the latest release-candidate chart and ContainerProfile-based workflows.
  * Added guidance for waiting for Kubescape Storage and aggregated API availability.
  * Updated workload labeling, example configurations, and R0011 guidance for public targets.
  * Refreshed signing and tamper-detection examples with the latest image and profile format.
  * Simplified the reference implementation overview by removing outdated migration notes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->