### PR TITLE
docs(integrations): fill empty GitHub page with GHA guide link

### DIFF
--- a/docs/docs/integrations/github.md
+++ b/docs/docs/integrations/github.md
@@ -1,0 +1,5 @@
+# GitHub
+
+Scan Kubernetes manifests and Helm charts in pull requests with the [Kubescape GitHub Action](https://github.com/kubescape/github-action).
+
+For a step-by-step walkthrough—enabling Actions, configuring the workflow, ignoring acceptable risks, and enforcing frameworks on PRs—see [Configure checks on a GitHub repository](../guides/kubescape-gha/index.md).


### PR DESCRIPTION
## Summary
- Replace empty `docs/integrations/github.md` stub with a short overview
- Link to the Kubescape GitHub Action and the existing GHA guide

fixes #137

