### PR TITLE
docs: fix Cursor MCP config to use mcpServers

### DIFF
--- a/docs/docs/mcp-server.md
+++ b/docs/docs/mcp-server.md
@@ -55,16 +55,15 @@ flowchart LR
    Add (or update) your `.cursor/mcp.json` configuration:
    ```json
    {
-     "servers": [
-       {
-         "name": "kubescape",
+     "mcpServers": {
+       "kubescape": {
          "command": "/absolute/path/to/kubescape",
          "args": ["mcpserver"]
        }
-     ]
+     }
    }
    ```
-   Restart Cursor  or Claude Desktop to pick up the new MCP integration.
+   Restart Cursor or Claude Desktop to pick up the new MCP integration.
 
 <!-- Screenshot placeholder: Cursor MCP configuration -->
 


### PR DESCRIPTION
## Overview
Fix the `.cursor/mcp.json` example in `mcp-server.md`: use `mcpServers` instead of the invalid `servers` array so Cursor/Claude Desktop setup works.
fixes #139

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the Cursor and Claude Desktop MCP configuration example to use the correct `mcpServers` format.
  * Clarified the instruction to restart the application after configuration changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->