### PR TITLE
docs(scanning): refresh the verbose-mode example to match current output

### DIFF
--- a/docs/docs/scanning.md
+++ b/docs/docs/scanning.md
@@ -46,13 +46,20 @@ Namespace: kube-system
 
 Controls: 1 (Failed: 1, action required: 0)
 
-┌──────────┬────────────────────────────────┬────────────────────────────────┬────────────────────────────────────┐
-│ SEVERITY │          CONTROL NAME          │              DOCS              │        ASSISTED REMEDIATION        │
-├──────────┼────────────────────────────────┼────────────────────────────────┼────────────────────────────────────┤
-│ Medium   │ Automatic mapping of service   │ https://ks.dev/controls/c-0034 │ automountServiceAccountToken=false │
-│          │ account                        │                                │                                    │
-└──────────┴────────────────────────────────┴────────────────────────────────┴────────────────────────────────────┘
+╭──────────┬──────────────────────────────────┬────────────────────────────────────┬────────────────────────────────────╮
+│ Severity │ Control name                     │ Docs                               │ Assisted remediation               │
+├──────────┼──────────────────────────────────┼────────────────────────────────────┼────────────────────────────────────┤
+│ Medium   │ Automatic mapping of service     │ https://hub.armosec.io/docs/c-0034 │ automountServiceAccountToken=false │
+│          │ account                          │                                    │                                    │
+╰──────────┴──────────────────────────────────┴────────────────────────────────────┴────────────────────────────────────╯
 ```
+
+When scanning files rather than a cluster, each block is preceded by a `Source:` line naming
+the file the resource came from.
+
+Assisted remediation identifies *where* to look: the JSON path of the field that triggered
+the control, with a suggested value appended for the paths Kubescape can fix (`path=value`).
+It does not show the value the field currently holds.
 
 ### Scanning files
 


### PR DESCRIPTION
## Overview

The example under **Verbose mode** in `docs/docs/scanning.md` shows output kubescape no longer
produces. Three differences from a current run, each traceable to the printer:

| Docs show | Actual output | Source |
|---|---|---|
| `┌ ┬ ┐` square borders | `╭ ┬ ╮` rounded | `resourcetable.go:59` sets `table.StyleBoxRounded` |
| `SEVERITY`, `CONTROL NAME` | `Severity`, `Control name` | `:58` uses `text.FormatDefault`; header row at `:129` |
| no `Source:` line | `Source: <file>` on file scans | `:42` |

Updated the block to match, and refreshed the control link to the `hub.armosec.io` form the CLI
actually prints.

## The added note

Two sentences after the example saying what assisted remediation is: the JSON path of the field
that triggered the control, with a suggested value appended on fix paths, and *not* the value the
field currently holds.

That distinction is the subject of [#1563](https://github.com/kubescape/kubescape/issues/1563)
and [#1737](https://github.com/kubescape/kubescape/issues/1737), where users were pointed at
`--verbose` expecting it to reveal the offending value and reported back that it doesn't. The
page currently describes assisted remediation as "Kubescape's suggestion of what parameters can
be changed", which is accurate but leaves that question open.

Describes current behaviour only.

## Verification

Compared against `kubescape scan control C-0012 <manifest> --verbose` built from
`kubescape@d5f1047`, and against the printer source cited above.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated verbose scan output examples with clearer table formatting and current links.
  * Documented file-scan source markers and assisted-remediation JSON paths.
  * Clarified suggested replacement values and when current field values are omitted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->